### PR TITLE
Add Dockerfile - Debian base with all dependencies installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM debian:jessie
+
+RUN REPO=http://cdn-fastly.deb.debian.org && \
+  echo "deb $REPO/debian jessie main\ndeb $REPO/debian jessie-updates main\ndeb $REPO/debian-security jessie/updates main" > /etc/apt/sources.list
+RUN echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" >> /etc/apt/sources.list.d/unstable.list
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update --yes
+RUN apt-get install --yes \
+  automake \
+  autogen \
+  bash \
+  build-essential \
+  git \
+  libgl1-mesa-dev \
+  x11proto-core-dev \
+  libx11-dev
+RUN apt-get install --yes -t unstable gcc-5 g++-5
+RUN echo 'Yes, do as I say!' | apt-get install libsdl2-dev
+RUN apt-get clean --yes
+
+# clone and build dependencies
+RUN git clone git://github.com/bkaradzic/bx.git && \
+  git clone git://github.com/bkaradzic/bimg.git && \
+  git clone git://github.com/bkaradzic/bgfx.git
+
+RUN cd bx && make linux-release64
+RUN cd bimg && make build CXX="g++-5" CC="gcc-5"
+RUN cd bgfx && make linux-release64
+RUN cd bgfx && make tools
+
+COPY . /bgfx-PlanetShader
+RUN mkdir -p /bgfx-PlanetShader/shaders/glsl
+RUN cd bgfx-PlanetShader && make


### PR DESCRIPTION
I've successfully used the container on an OSX host machine to build the renderer on Debian, then export it and run it on Ubuntu in a VirtualBox VM.

To build the container:

```
docker build -t planet-shader .
```

To run it in interactive mode:

```
docker run -it --rm planet-shader
```

While it's running in interactive mode, you can copy the files that were built:

```
docker ps
CONTAINER ID        IMAGE               COMMAND             CREATED                  STATUS              PORTS               NAMES
ce8ec55d344f        planet-shader       "bash"              Less than a second ago   Up 8 seconds                            laughing_benz
docker cp ce8ec55d344f:/bgfx-PlanetShader/renderer renderer
```

The Dockerfile could be improved by adding instructions to create a zip archive of the executable and the required artifacts (`.bin` files, textures) and automatically export it to the host machine somehow (probably using volumes).

Another, more important thing, would be to checkout specific commits from the git repos (dependencies and planet shader) so that the build is consistent. With the current setup if the dependencies have breaking changes the build will break again.