### PR TITLE
Make code compatible with updated dependencies (bg, bgfx)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,24 +9,24 @@ BIMG_DIRECTORY=../bimg/
 INCLUDES=-I$(BGFX_DIRECTORY)include/ -I$(BX_DIRECTORY)include/ -I$(BGFX_DIRECTORY)3rdparty
 LIBRARIES=-L$(BGFX_DIRECTORY).build/linux64_gcc/obj/x64/Release/bgfx/src -L$(BX_DIRECTORY).build/linux64_gcc/obj/x64/Release/bx/src
 GCC=g++
-SHADERC=$(BGFX_DIRECTORY)/tools/bin/linux/shaderc
-GEOMETRYC=$(BGFX_DIRECTORY)/toosl/bin/linux/geometryc
+SHADERC=$(BGFX_DIRECTORY)tools/bin/linux/shaderc
+GEOMETRYC=$(BGFX_DIRECTORY)toosl/bin/linux/geometryc
 USERCXXFLAGS= -g -std=c++14
 
 #make sure we have XLIB and SDL2 packages first!!!
 #if you do not please use your package manager to install them
-LIBS= -lrt -ldl -lX11 -lGL -lGLU -lpthread -lSDL2 
+LIBS= -lrt -ldl -lX11 -lGL -lGLU -lpthread -lSDL2
 #linking each file cause there are dx11 references
 BGFX_ALL=$(BGFX_DIRECTORY).build/linux64_gcc/obj/x64/Release/bgfx/src/*.o
 BX_ALL=$(BX_DIRECTORY).build/linux64_gcc/obj/x64/Release/bx/src/*.o
 BIMG_ALL=$(BIMG_DIRECTORY).build/linux64_gcc/obj/x64/Release/bimg/src/*.o
 LDFLAGS += $(LIBRARIES)
-LDFLAGS += -static 
+LDFLAGS += -static
 
 all: baseapplication.o programloader.o mesh.o texture.o memory.o makeshaders indexbufferdecompression.o skybox.o
 	$(GCC) $(USERCXXFLAGS) $(BIMG_ALL) $(BX_ALL) $(LIBS) $(INCLUDES) $(BGFX_ALL) programloader.o baseapplication.o memory.o texture.o mesh.o indexbufferdecompression.o skybox.o main.cpp -o renderer
 
-baseapplication.o: baseapplication.h baseapplication.cpp 
+baseapplication.o: baseapplication.h baseapplication.cpp
 	$(GCC) $(USERCXXFLAGS) $(BIMG_ALL) $(BX_ALL) $(LIBS) $(INCLUDES) $(BGFX_ALL) baseapplication.cpp -c
 
 programloader.o: engine/programloader.h engine/programloader.cpp
@@ -60,7 +60,7 @@ makeshaders: makeshadervert makeshaderfrag
 makeshadervert: vs_planet.glsl vs_atmo.glsl vs_skybox.glsl
 	$(SHADERC) -f vs_planet.glsl -o shaders/glsl/vs_planet.bin --type vertex --platform linux -p 120 --varyingdef varying.def.sc --verbose
 	$(SHADERC) -f vs_atmo.glsl -o shaders/glsl/vs_atmo.bin --type vertex --platform linux -p 120 --varyingdef varying.def.sc --verbose
-	$(SHADERC) -f vs_skybox.glsl -o shaders/glsl/vs_skybox.bin --type vertex --platform linux -p 120 --varyingdef varying.def.sc --verbose	
+	$(SHADERC) -f vs_skybox.glsl -o shaders/glsl/vs_skybox.bin --type vertex --platform linux -p 120 --varyingdef varying.def.sc --verbose
 
 makeshaderfrag: fs_planet.glsl fs_atmo.glsl
 	$(SHADERC) -f fs_planet.glsl -o shaders/glsl/fs_planet.bin --type fragment --platform linux -p 120 --varyingdef varying.def.sc --verbose

--- a/baseapplication.cpp
+++ b/baseapplication.cpp
@@ -2,8 +2,6 @@
 #include "baseapplication.h"
 
 
-
-
 BaseApplication::BaseApplication() : m_mainWindow(0)
 {
 	m_width = 1280;
@@ -45,7 +43,9 @@ void BaseApplication::setupWindow()
 	pd.backBuffer = NULL;
 	pd.backBufferDS = NULL;
 	bgfx::setPlatformData(pd);
-	bgfx::init( bgfx::RendererType::OpenGL);
+	bgfx::Init init;
+	init.type = bgfx::RendererType::OpenGL;
+	bgfx::init(init);
 	//bgfx::sdlSetWindow(m_mainWindow);
 }
 
@@ -68,7 +68,7 @@ void BaseApplication::setupViews()
 	float eyeUniform[4] = { temp[0], temp[1],temp[2], m_rotate};
 	bgfx::setUniform(cameraPosition, eyeUniform);
 	float proj[16];
-	bx::mtxProj(proj, 60.0f, float(m_width)/float(m_height), 0.1f, 100.0f);
+	bx::mtxProj(proj, 60.0f, float(m_width)/float(m_height), 0.1f, 100.0f, true);
 	bgfx::setViewRect(0, 0, 0, m_width, m_height);
 	bgfx::setViewTransform(0, view, proj);
 	bgfx::setViewRect(1, 0, 0, m_width, m_height);
@@ -114,11 +114,11 @@ void BaseApplication::run()
 	bgfx::setViewName(0, "skybox");
 	bgfx::setViewName(1, "atmosphere");
 	bgfx::setViewName(2, "planet");
-	
+
 	uint64_t state = 0
-		| BGFX_STATE_RGB_WRITE
-		| BGFX_STATE_ALPHA_WRITE
-		| BGFX_STATE_DEPTH_WRITE
+		| BGFX_STATE_WRITE_RGB
+		| BGFX_STATE_WRITE_A
+		| BGFX_STATE_WRITE_Z
 		| BGFX_STATE_BLEND_ALPHA
 		| BGFX_STATE_CULL_CCW
 		| BGFX_STATE_MSAA;
@@ -126,7 +126,7 @@ void BaseApplication::run()
 	bgfx::ProgramHandle atmo_program = m_programloader.loadProgram("vs_atmo", "fs_atmo");
 	bgfx::ProgramHandle skybox_program = m_programloader.loadProgram("vs_skybox", "fs_skybox");
 	Mesh *mesh = meshLoad("sphere.bin");
-	Mesh *atmo = meshLoad("sphere.bin");	
+	Mesh *atmo = meshLoad("sphere.bin");
 	mesh->addTexture("mars_map.png",  0 | BGFX_TEXTURE_U_MIRROR
 					  | BGFX_TEXTURE_V_MIRROR
 					  | BGFX_TEXTURE_W_MIRROR);
@@ -165,7 +165,7 @@ void BaseApplication::run()
 		// Advance to next frame. Rendering thread will be kicked to
 		// process submitted rendering primitives.
 		bgfx::frame();
-		
+
 		while(SDL_PollEvent(&event))
 		{
 			switch(event.type)
@@ -185,7 +185,7 @@ void BaseApplication::run()
 					exit = true;
 				}
 				break;
-				
+
 			}
 			case SDL_MOUSEBUTTONDOWN:
 			{
@@ -197,7 +197,7 @@ void BaseApplication::run()
 			case SDL_WINDOWEVENT:
 			{
 				//needed to resize the rendering window
-				
+
 				if(event.window.event == SDL_WINDOWEVENT_RESIZED)
 				{
 					m_width = event.window.data1;
@@ -206,7 +206,7 @@ void BaseApplication::run()
 
 					bgfx::reset(m_width, m_height, reset);
 				}
-				
+
 			}
 			}
 		}
@@ -216,6 +216,6 @@ void BaseApplication::run()
 	delete mesh;
 	delete atmo;
 
-	bgfx::destroyProgram(planet_program);
-	bgfx::destroyProgram(atmo_program);
+	bgfx::destroy(planet_program);
+	bgfx::destroy(atmo_program);
 }

--- a/baseapplication.h
+++ b/baseapplication.h
@@ -8,9 +8,9 @@
 
 #include <stdio.h>
 #include <bx/handlealloc.h>
-#include <bx/fpumath.h>
 #include <bx/readerwriter.h>
 #include <bx/string.h>
+#include <bx/math.h>
 
 #include <GL/gl.h>
 
@@ -39,7 +39,7 @@ protected:
 	float m_distance;
 	float m_rotate;
 	ProgramLoader m_programloader;
-	
+
 	bgfx::UniformHandle cameraPosition;
 };
 

--- a/engine/mesh.cpp
+++ b/engine/mesh.cpp
@@ -28,9 +28,9 @@ void Mesh::load(bx::ReaderSeekerI* _reader)
 	using namespace bgfx;
 	Group group;
 
-		
-	//bx::AllocatorI* allocator = new bx::CrtAllocator;
-	bx::CrtAllocator allocator;
+
+	//bx::AllocatorI* allocator = new bx::DefaultAllocator;
+	bx::DefaultAllocator allocator;
 	uint32_t chunk;
 	while (4 == bx::read(_reader, chunk) )
 	{
@@ -141,9 +141,9 @@ void Mesh::submit(uint8_t _id, bgfx::ProgramHandle _program, const float* _mtx, 
 	if (BGFX_STATE_MASK == _state)
 	{
 		_state = 0
-			| BGFX_STATE_RGB_WRITE
-			| BGFX_STATE_ALPHA_WRITE
-			| BGFX_STATE_DEPTH_WRITE
+			| BGFX_STATE_WRITE_RGB
+			| BGFX_STATE_WRITE_A
+			| BGFX_STATE_WRITE_Z
 			| BGFX_STATE_DEPTH_TEST_LESS
 			| BGFX_STATE_CULL_CCW
 			| BGFX_STATE_MSAA
@@ -160,7 +160,7 @@ void Mesh::submit(uint8_t _id, bgfx::ProgramHandle _program, const float* _mtx, 
 		const Group& group = *it;
 		bgfx::setTransform(cached);
 		bgfx::setIndexBuffer(group.m_ibh);
-		bgfx::setVertexBuffer(group.m_vbh);
+		bgfx::setVertexBuffer(0, group.m_vbh);
 		bgfx::setState(_state);
 		bgfx::submit(_id, _program);
 	}
@@ -180,7 +180,7 @@ void Mesh::setTexture(int _index, const char* _name, uint32_t _flags)
 	int stage = _index;
 	Texture *newTexture = new Texture(stage);
 	newTexture->loadTexture(_name, _flags);
-	m_textures.push_back(newTexture);	
+	m_textures.push_back(newTexture);
 }
 
 
@@ -195,7 +195,7 @@ Mesh* meshLoad(bx::ReaderSeekerI* _reader)
 Mesh* meshLoad(const char* _filePath)
 {
 
-	bx::CrtFileReader reader;
+	bx::FileReader reader;
 	bx::open(&reader, _filePath);
 	Mesh* mesh = meshLoad(&reader);
 	bx::close(&reader);

--- a/engine/mesh.h
+++ b/engine/mesh.h
@@ -5,10 +5,10 @@
 #include <bgfx/platform.h>
 #include <bgfx/defines.h>
 #include <bx/commandline.h>
-#include <bx/fpumath.h>
 #include <bx/readerwriter.h>
+#include <bx/file.h>
+#include <bx/math.h>
 #include <bx/string.h>
-#include <bx/crtimpl.h>
 #include <vector>
 #include <string>
 #include "texture.h"
@@ -57,8 +57,8 @@ struct Group
 
 	void reset()
 		{
-			m_vbh.idx = bgfx::invalidHandle;
-			m_ibh.idx = bgfx::invalidHandle;
+			m_vbh.idx = bgfx::kInvalidHandle;
+			m_ibh.idx = bgfx::kInvalidHandle;
 			m_prims.clear();
 		}
 

--- a/engine/programloader.h
+++ b/engine/programloader.h
@@ -8,10 +8,10 @@
 #include <stdio.h>
 #include <bgfx/platform.h>
 
+#include <bx/file.h>
 #include <bx/handlealloc.h>
 #include <bx/readerwriter.h>
 #include <bx/string.h>
-#include <bx/crtimpl.h>
 
 
 #include <bgfx/bgfx.h>
@@ -26,7 +26,7 @@ public:
 	bgfx::ShaderHandle loadShader(bx::FileReaderI* reader, const char* name);
 	bgfx::ProgramHandle loadProgram(const char* vsName, const char* fsName);
 protected:
-	bx::CrtFileReader m_reader;
+	bx::FileReader m_reader;
 };
 
 #endif

--- a/engine/skybox.cpp
+++ b/engine/skybox.cpp
@@ -32,7 +32,7 @@ PosColorTexCoord0Vertex northface[4] = //heh
 	{-1.0f,  1.0f,  1.0f, 0, 0},
 	{ 1.0f,  1.0f,  1.0f, 1.0, 0 },
 	{-1.0f, -1.0f,  1.0f, 0, 1.0 },
-	{ 1.0f, -1.0f,  1.0f, 1.0, 1.0 },	
+	{ 1.0f, -1.0f,  1.0f, 1.0, 1.0 },
 };
 
 const uint16_t northface_indices[6] =
@@ -41,7 +41,7 @@ const uint16_t northface_indices[6] =
 	1, 3, 2,
 };
 
-PosColorTexCoord0Vertex southface[4] = 
+PosColorTexCoord0Vertex southface[4] =
 {
 	{-1.0f,  1.0f, -1.0f, 0, 0 },
 	{ 1.0f,  1.0f, -1.0f, 1.0, 0 },
@@ -66,7 +66,7 @@ static PosColorTexCoord0Vertex s_cubeVertices[8] =
 	{ 1.0f,  1.0f,  1.0f, 1.0, 0 },
 	{-1.0f, -1.0f,  1.0f, 0, 1.0 },
 	{ 1.0f, -1.0f,  1.0f, 1.0, 1.0 },
-	
+
 	{-1.0f,  1.0f, -1.0f, 1.0, 0 },
 	{ 1.0f,  1.0f, -1.0f, 0, 0 },
 	{-1.0f, -1.0f, -1.0f, 1.0, 1.0 },
@@ -91,8 +91,8 @@ static const uint16_t s_cubeIndices[36] =
 
 Skybox::~Skybox()
 {
-	bgfx::destroyVertexBuffer(m_vbh);
-	bgfx::destroyIndexBuffer(m_ibh);
+	bgfx::destroy(m_vbh);
+	bgfx::destroy(m_ibh);
 }
 
 void Skybox::setupSkybox()
@@ -129,7 +129,7 @@ void Skybox::renderSkybox(bgfx::ProgramHandle program)
 	float mtx[16];
 	bx::mtxScale(mtx, 8, 8, 8);
 	bgfx::setTransform(mtx);
-	bgfx::setVertexBuffer(m_vbh);
+	bgfx::setVertexBuffer(0, m_vbh);
 	bgfx::setIndexBuffer(m_ibh);
 	bgfx::setState(BGFX_STATE_DEFAULT);
 	m_texture.setTexture();

--- a/engine/skybox.h
+++ b/engine/skybox.h
@@ -6,8 +6,8 @@
 #include <bgfx/defines.h>
 
 #include <bx/handlealloc.h>
-#include <bx/fpumath.h>
 #include <bx/readerwriter.h>
+#include <bx/math.h>
 #include <bx/string.h>
 
 #include "texture.h"
@@ -19,7 +19,7 @@
 class Skybox
 {
 public:
-	
+
 	~Skybox();
 	void setupSkybox();
 	void renderSkybox(bgfx::ProgramHandle program);
@@ -39,7 +39,7 @@ protected:
 	bgfx::IndexBufferHandle m_indices_northface;
 
 	bgfx::VertexBufferHandle m_verts_southface;
-	bgfx::IndexBufferHandle m_indices_southface;	
+	bgfx::IndexBufferHandle m_indices_southface;
 	Texture m_texture;
 };
 

--- a/engine/texture.cpp
+++ b/engine/texture.cpp
@@ -13,8 +13,8 @@ Texture::Texture(int _stage) : m_stage(_stage)
 
 Texture::~Texture()
 {
-	bgfx::destroyTexture(m_texture);
-	bgfx::destroyUniform(m_uniform);
+	bgfx::destroy(m_texture);
+	bgfx::destroy(m_uniform);
 }
 
 void Texture::loadTexture(const char* _name, uint32_t _flags, uint8_t _skip, bgfx::TextureInfo* _info)
@@ -29,8 +29,8 @@ void Texture::loadTexture(const char* _name, uint32_t _flags, uint8_t _skip, bgf
 	strcat(filePath, _name);
 
 	bgfx::TextureHandle handle = BGFX_INVALID_HANDLE;
-	bx::CrtAllocator allocator;
-	bx::CrtFileReader _reader;
+	bx::DefaultAllocator allocator;
+	bx::FileReader _reader;
 	uint32_t size = 0;
 	void* data = loadMem(&_reader, &allocator, filePath, &size);
 	if (NULL != data)
@@ -40,7 +40,7 @@ void Texture::loadTexture(const char* _name, uint32_t _flags, uint8_t _skip, bgf
 		int comp   = 0;
 
 		uint8_t* img = NULL;
-		
+
 		img = stbi_load_from_memory( (uint8_t*)data, size, &width, &height, &comp, 4);
 		BX_FREE(&allocator, data);
 

--- a/engine/texture.h
+++ b/engine/texture.h
@@ -3,9 +3,9 @@
 
 #include <bgfx/bgfx.h>
 #include <bx/readerwriter.h>
+#include <bx/file.h>
 #include <bgfx/platform.h>
 #include <bgfx/defines.h>
-#include <bx/crtimpl.h>
 #include "memory.h"
 
 
@@ -20,8 +20,8 @@ public:
 	void setStage(int _stage);
 	void setTexture() const;
 
-	
-protected:   
+
+protected:
 	bgfx::TextureHandle m_texture;
 	bgfx::UniformHandle m_uniform;
 	int m_stage;


### PR DESCRIPTION
The change should not affect functionality in any way - I've not worked with bg/bgfx before so I've only tried to replace the deprecated with their equivalents. 

I built the renderer using a docker container (see https://github.com/benquach16/bgfx-PlanetShader/pull/4) and I was able to run it in a Ubuntu VM with libsdl2 installed. When clicking around or pressing a few keys, the window closes but there's no error message or core dump.

My editor automatically trims trailing spaces, so some of the diff will be whitespace changes - sorry about that!